### PR TITLE
return classes once per file

### DIFF
--- a/Autoloader/parser/AutoloaderFileParser.php
+++ b/Autoloader/parser/AutoloaderFileParser.php
@@ -158,7 +158,14 @@ abstract class AutoloaderFileParser
      */
     public function getClassesInFile($file)
     {
-        return $this->getClassesInSource($this->_getSource($file));
+        $classesInSource = $this->getClassesInSource($this->_getSource($file));
+        $ret = array();
+
+        foreach ($classesInSource as $class) {
+            $ret[$class] = true;
+        }
+
+        return array_keys($ret);
     }
 
     /**


### PR DESCRIPTION
The index generation will break if frameworks define classes conditional, e.g.

```
if (class_exists("Zend_Exception")) {
    abstract class Zend_InfoCard_Exception_Abstract extends Zend_Exception
    {
    }
} else {
    abstract class Zend_InfoCard_Exception_Abstract extends Exception
    {
    }
}
```

Even if this is a stupid pattern, it's used in Frameworks like ZendFramework and Codeigniter. See http://framework.zend.com/svn/framework/standard/trunk/library/Zend/InfoCard/Exception.php